### PR TITLE
Remove 'Verified' from messages filter

### DIFF
--- a/test_result-0.1.html
+++ b/test_result-0.1.html
@@ -101,7 +101,7 @@
           // Get all messages to current patchset with Verified verdict
           var verifiedMessages = this.change.messages.filter(it =>
               it.message.startsWith('Patch Set ' +
-                current_patchset + ': Verified'));
+                current_patchset + ':'));
 
           // Gather checks info from messages
           // check formats:


### PR DESCRIPTION
Sometimes if you recheck, jenkins will write a post without changing the label (if it still fails).