### PR TITLE
To raise compatibility, stop named capture groups in regular expressions

### DIFF
--- a/test_result-0.1.html
+++ b/test_result-0.1.html
@@ -47,9 +47,10 @@
         <div class="gr-file-list">
 
           <div class="patchInfo-header gr-file-list-header">
-            <span class="path gr-file-list" title="[[item.checker]]">
-              [[item.checker]]
-            </span>
+            <gr-account-label
+              account=[[item.checker]]
+              class="authorLabel"
+            >
             <span class="path gr-file-list" id="checker-date">
               <gr-date-formatter date-str="[[item.date]]"></gr-date-formatter>
             </span>
@@ -119,7 +120,7 @@
               var checker = _checkers[it.author._account_id];
               if (checker === undefined) {
                 checker = _checkers[it.author._account_id] = {
-                  checker: it.author.name,
+                  checker: it.author,
                   account_id : it.author._account_id,
                   checks: _checks,
                   date: it.date

--- a/test_result-0.1.html
+++ b/test_result-0.1.html
@@ -154,13 +154,13 @@
           var check;
           var checks = {};
 
-          var re = /(?:Build (?<st>Started) )?(?<url>http[^ ]+\/job\/(?<name>[^\/ ]+)\/[^ ]+)(?: : (?<result>[A-Z_]+)(?<spent> .*)?$)?/gm;
+          var re = /(?:Build (Started) )?(http[^ ]+\/job\/([^\/ ]+)\/[^ ]+)(?: : ([A-Z_]+)( .*)?$)?/gm;
           while (check = re.exec(message)) {
-            checks[check.groups.name] = {
-              name: check.groups.name,
-              url: check.groups.url,
-              result: check.groups.st || check.groups.result,
-              spent: check.groups.spent,
+            checks[check[3]] = {
+              name: check[3],
+              url: check[2],
+              result: check[1] || check[4],
+              spent: check[5],
             };
           };
 


### PR DESCRIPTION
Firefox received support for named capture groups in regular
expressions, in version 78. But Debian Buster (current stable as of
2020) only ships Firefox 68.10. So the script using named capture
groups failed on Debian stable. Hence, we're switching to unnamed
groups to raise compatibility with browsers.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Browser_compatibility